### PR TITLE
[#11] Fix bugs to download images with unique urls

### DIFF
--- a/js/messageReceiver.js
+++ b/js/messageReceiver.js
@@ -21,16 +21,15 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         sendResponse(false);
     } else if (request.type == 'tweetdeck') {
         const link = document.getElementsByClassName("js-media-image-link");
-        var targetImageList = [];
+        var targetImageList = new Set();
 
         for (var i = 0; i < link.length; i++) {
             if (link[i].href == request.link) {
                 const imageUrl = link[i].style.backgroundImage; // scheme: url("${imageUrl}")
-                targetImageList.push(imageUrl.split("\"")[1]);
+                targetImageList.add(imageUrl.split("\"")[1]);
             }
         }
-
-        sendResponse(targetImageList);
+        sendResponse(Array.from(targetImageList));
     } else {
         sendResponse(null);
     }

--- a/js/operation.js
+++ b/js/operation.js
@@ -113,8 +113,8 @@ chrome.contextMenus.onClicked.addListener(function onClick(info, tab) {
 
 
 function downloadTwitterImages(imageUrls) {
-    for (var index in imageUrls) {
-        const urlMap = parsingTwitterUrl(imageUrls[index]);
+    for (let imageUrl of imageUrls) {
+        const urlMap = parsingTwitterUrl(imageUrl);
         downloadImage(urlMap["baseUrl"] + "?format=" + urlMap["format"] + "&name=4096x4096");
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "Original Size Image Downloader",
 	"description": "트위터, Tweetdeck, 티스토리, 인스타그램, 다음카페에서 원본 이미지를 쉽게 다운받아주는 프로그램",
-	"version": "0.40",
+	"version": "0.41",
 	"permissions": [
 		"contextMenus",
 		"downloads",


### PR DESCRIPTION
## 수정사항

기존
다운로드할 이미지의 목록을 리스트로 구현 -> 중복으로 다운로드가 가능해짐

수정 후
다운로드할 이미지의 목록을 Set으로 구현 -> 중복으로 다운로드 불가능
